### PR TITLE
docs(about_us): use new organization name to avoid github link access 404

### DIFF
--- a/documentation/release/html/_sources/about_us.rst.txt
+++ b/documentation/release/html/_sources/about_us.rst.txt
@@ -22,7 +22,7 @@
 
 - 官网： http://www.embedfire.com
 - 论坛： http://www.firebbs.cn
-- github主页：https://github.com/Embdefire
+- github主页：https://github.com/Embedfire
 - gitee主页： https://gitee.com/wildfireteam
 - 淘宝： https://yehuosm.tmall.com
 - 邮箱： embedfire@embedfire.com

--- a/documentation/release/html/about_us.html
+++ b/documentation/release/html/about_us.html
@@ -203,7 +203,7 @@
 <ul class="simple">
 <li><p>官网： <a class="reference external" href="http://www.embedfire.com">http://www.embedfire.com</a></p></li>
 <li><p>论坛： <a class="reference external" href="http://www.firebbs.cn">http://www.firebbs.cn</a></p></li>
-<li><p>github主页：<a class="reference external" href="https://github.com/Embdefire">https://github.com/Embdefire</a></p></li>
+<li><p>github主页：<a class="reference external" href="https://github.com/Embedfire">https://github.com/Embedfire</a></p></li>
 <li><p>gitee主页： <a class="reference external" href="https://gitee.com/wildfireteam">https://gitee.com/wildfireteam</a></p></li>
 <li><p>淘宝： <a class="reference external" href="https://yehuosm.tmall.com">https://yehuosm.tmall.com</a></p></li>
 <li><p>邮箱： <a class="reference external" href="mailto:embedfire&#37;&#52;&#48;embedfire&#46;com">embedfire<span>&#64;</span>embedfire<span>&#46;</span>com</a></p></li>


### PR DESCRIPTION
## Before

https://github.com/Embdefire

Access 404

## After

https://github.com/Embedfire

Access normal